### PR TITLE
Clear timeouts when destroying Agent.

### DIFF
--- a/http.js
+++ b/http.js
@@ -302,6 +302,11 @@ Agent.prototype.destroy = function() {
   sets.forEach(function(set) {
     Object.keys(set).forEach(function(name) {
       set[name].forEach(function(socket) {
+        // Clear timeouts if they exist.
+        if (socket._yakaa_timeout) {
+          clearTimeout(socket._yakaa_timeout);
+          delete socket._yakaa_timeout;
+        }
         socket.destroy();
       });
     });


### PR DESCRIPTION
In cases where keepAlive is being used, setTimeouts are not being cleared when the Agent is destroyed and node, by default, is staying alive. Using [wtfnode](https://www.npmjs.com/package/wtfnode) can reveal this. In most cases, this is negligible, but for example, when deployed to Lambda, keeping node alive is not ideal as it has max timeouts 

> All calls made to AWS Lambda must complete execution within 300 seconds. The default timeout is 3 seconds, but you can set the timeout to any value between 1 and 300 seconds.
> (https://aws.amazon.com/lambda/faqs/)
